### PR TITLE
Only include requirements if needed

### DIFF
--- a/code/DisplayLogicFormField.php
+++ b/code/DisplayLogicFormField.php
@@ -100,12 +100,14 @@ class DisplayLogicFormField extends DataExtension {
 	 * @return  string
 	 */
 	public function DisplayLogic() {
-		Requirements::javascript(THIRDPARTY_DIR.'/jquery-entwine/dist/jquery.entwine-dist.js');
-		Requirements::javascript(DISPLAY_LOGIC_DIR.'/javascript/display_logic.js');
-		Requirements::css(DISPLAY_LOGIC_DIR.'/css/display_logic.css');		
-		if($this->displayLogicCriteria) {			
+		if($this->displayLogicCriteria) {
+			Requirements::javascript(THIRDPARTY_DIR.'/jquery-entwine/dist/jquery.entwine-dist.js');
+			Requirements::javascript(DISPLAY_LOGIC_DIR.'/javascript/display_logic.js');
+			Requirements::css(DISPLAY_LOGIC_DIR.'/css/display_logic.css');
+
 			return $this->displayLogicCriteria->toScript();
 		}
+		
 		return false;
 	}
 


### PR DESCRIPTION
Only set the javascript and css requirements if displayLogicCriteria is set.

This also fixes an issue we ran into where we wanted to use display logic in the CMS, but found we were getting javascript errors on the frontend of the site because we weren't using jQuery for the frontend.
