### PR TITLE
Fix exception when this.data() returns undefined

### DIFF
--- a/javascript/display_logic.js
+++ b/javascript/display_logic.js
@@ -96,7 +96,9 @@
 		},
 
 		getMasters: function() {
-			return this.data('display-logic-masters').split(",");
+			var masters = this.data('display-logic-masters');
+
+			return (masters) ? masters.split(",") : [];
 		}
 
 	});


### PR DESCRIPTION
Was throwing an exception in the CMS (running 3.1.1) looks like this.data() returned undefined where the data attribute didn't exist.
