### PR TITLE
Module doesn't have a specific need to have the CMS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
     ],
     "require":
     {
-        "silverstripe/framework": "3.*",
-	    "silverstripe/cms": "3.*"
+        "silverstripe/framework": "3.*"
     },
     "extra": {
 	"installer-name": "display_logic"


### PR DESCRIPTION
Allows it to be used on framework only installs.
