### PR TITLE
Fixed error with field names that contained []

### DIFF
--- a/code/DisplayLogicCriterion.php
+++ b/code/DisplayLogicCriterion.php
@@ -79,8 +79,9 @@ class DisplayLogicCriterion extends Object {
 	 */
 	public function toScript() {		
 		return sprintf(
-			"this.closest('form').find('#%s').evaluate{$this->operator}('%s')",
+			"this.closest('form').find(this.escapeSelector('#%s')).evaluate%s('%s')",
 			$this->master,
+			$this->operator,
 			addslashes($this->value)
 		);
 	}

--- a/javascript/display_logic.js
+++ b/javascript/display_logic.js
@@ -3,8 +3,16 @@
 
 	$('div.display-logic, div.display-logic-master').entwine({
 
+		escapeSelector: function(selector) {
+			return selector.replace(/(\[|])/g, '\\$1');
+		},
+
 		getFormField: function() {
-			return this.find('[name='+this.getFieldName()+']');
+			var name = this.getFieldName();
+			if (name) {
+				name = this.escapeSelector(name);
+			}
+			return this.find('[name='+name+']');
 		},
 
 		getFieldName: function() {
@@ -87,7 +95,7 @@
 
 			masters = this.getMasters();			
 			for(m in masters) {				
-				var master = this.closest('form').find('#'+masters[m]);		
+				var master = this.closest('form').find(this.escapeSelector('#'+masters[m]));
 				if(!master.is('.readonly')) allReadonly = false;
 
 				master.addClass("display-logic-master");
@@ -160,7 +168,7 @@
 
 	$('input[type=checkbox]').entwine({
 		getLabel: function() {
-			return this.closest('form').find('label[for='+this.attr('id')+']');
+			return this.closest('form').find('label[for='+this.getHolder().escapeSelector(this.attr('id'))+']');
 		}
 	})
 


### PR DESCRIPTION
values containing square brackets in queries for `document.querySelectorAll()` have to be escaped in order to work.
(This is because querySelectorAll() / jQuery supports attribute selectors such as '[name=foo]', a query for the ID 'foo[bar]' would become `document.querySelectorAll('#foo[bar]')` which means: "get all elements with the ID 'foo' and the attribute 'bar'.)