### PR TITLE
BUGFIX: Fixed issue where DisplayLogicWrapper's would not work when using hideIf or displayUnless

### DIFF
--- a/javascript/display_logic.js
+++ b/javascript/display_logic.js
@@ -271,7 +271,7 @@
 		}
 	});
 
-	$('div.display-logic.displaylogicwrapper.display-logic-display').entwine({
+	$('div.display-logic.displaylogicwrapper.display-logic-display, div.display-logic.displaylogicwrapper.display-logic-hide').entwine({
 		getFormField: function () {
 			return this;
 		},


### PR DESCRIPTION
When using ``hideIf`` or ``displayUnless`` the css class added to the DisplayLogicWrapper would be display-logic-hide, which is causing the JavaScript bindings to not find the form field.