### PR TITLE
Allow multiple nested groups

### DIFF
--- a/code/DisplayLogicCriteria.php
+++ b/code/DisplayLogicCriteria.php
@@ -188,6 +188,7 @@ class DisplayLogicCriteria extends Object {
 	public function end() {
 		if($this->parent) {
 			$this->parent->addCriterion($this);
+			return $this->parent;
 		}
 		return $this->slave;
 	}


### PR DESCRIPTION
Hi @unclecheese,

I hit a wall when I was trying to nest multiple groups inside each other, combining AND and OR conditions, attempting to create custom logic based on multiple fields.

It only seemed to work fine with one group at a time. The suggested change in this pull request made it work exactly the way I needed and also didn't break anything else, but I'm not 100% certain it's the right thing. Can you have a look, test some of your scenarios and give me some feedback?

Cheers
Michal