### PR TITLE
BUGFIX: Fixed compatibility with changes to optionset in SilverStripe 3.4

### DIFF
--- a/javascript/display_logic.js
+++ b/javascript/display_logic.js
@@ -33,7 +33,7 @@
 			// Hack!
 			// Remove this when OptionsetField_holder.ss uses $HolderID
 			// as its div ID instead of $ID
-			if(this.closest('form').find('ul[name='+name+']').length) {
+			if(this.closest('form').find('ul.optionset li input[name='+name+']:first').length) {
 				return name;
 			}
 


### PR DESCRIPTION
SilverStripe 3.4 removes the invalid name attribute from the optionset unordered list tag, which is breaking the nameToHolder method in JS. See commit [288c8a8b272af85cf1b62d82b5633e16bbf44d15](https://github.com/silverstripe/silverstripe-framework/commit/288c8a8b272af85cf1b62d82b5633e16bbf44d15). This pull request now looks to the first input in an optionset unordered list.