### PR TITLE
BUGFIX: Fields nested inside of a FieldGroup cannot be a master

### DIFF
--- a/templates/FieldGroup.ss
+++ b/templates/FieldGroup.ss
@@ -1,0 +1,7 @@
+<div class="<% if $extraClass %>$extraClass<% else %>fieldgroup<% end_if %><% if $Zebra %> fieldgroup-zebra<% end_if %>" <% if $ID %>id="$ID"<% end_if %>>
+	<% loop $FieldList %>
+		<div class="fieldgroup-field $FirstLast $EvenOdd" id="$HolderID">
+			$SmallFieldHolder
+		</div>
+	<% end_loop %>
+</div>

--- a/templates/FieldGroup_holder.ss
+++ b/templates/FieldGroup_holder.ss
@@ -1,0 +1,14 @@
+<div <% if $Name %>id="$Name"<% end_if %> class="field <% if $extraClass %>$extraClass<% end_if %>">
+	<% if $Title %><label class="left">$Title</label><% end_if %>
+
+	<div class="middleColumn fieldgroup<% if $Zebra %> fieldgroup-$Zebra<% end_if %>">
+		<% loop $FieldList %>
+			<div class="fieldgroup-field $FirstLast $EvenOdd" id="$HolderID">
+				$SmallFieldHolder
+			</div>
+		<% end_loop %>
+	</div>
+	<% if $RightTitle %><label class="right">$RightTitle</label><% end_if %>
+	<% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
+	<% if $Description %><span class="description">$Description</span><% end_if %>
+</div>


### PR DESCRIPTION
When you have a field such as a checkbox inside of a FieldGroup it cannot be used as a display logic master, because the div field's SmallFieldHolder is rendered into does not have the HolderID for the field. This pull request adds templates to override FieldGroup to include the HolderID on the field's containing div. This allows display logic's existing scripting to work as expected.