### PR TITLE
BUGFIX: Fixed issue merging nested DisplayLogicCriteria

### DIFF
--- a/code/DisplayLogicCriteria.php
+++ b/code/DisplayLogicCriteria.php
@@ -222,7 +222,7 @@ class DisplayLogicCriteria extends Object {
 		$list = array ();
 		foreach($this->getCriteria() as $c) {
 			if($c instanceof DisplayLogicCriteria) {
-				$list += $c->getMasterList();
+				$list=array_merge($list, $c->getMasterList());
 			}
 			else {
 				$list[] = $c->getMaster();


### PR DESCRIPTION
This pull request corrects an issue merging the masters list from nested display logic criteria where the first master in a group would be ignored in the below example. According to the PHP docs the plus operator when used for appending arrays duplicate indexes are ignored from the second array. From the docs "If an array key exists in both arrays, then the element from the first array will be used and the matching key's element from the second array will be ignored." ([source](http://php.net/manual/en/function.array-merge.php)), I ran into this issue on PHP 5.6.20 windows.

```php
$myField->displayIf('CheckboxField')->isChecked()
                    ->orIf()
                        ->group()
                            ->andIf('CheckboxField2')->isChecked()
                            ->andIf('OptionsetField')->isEqualTo('fourUp')
                    ->end();
```

In this example CheckboxField2 is omitted from the masters list, with this pull request it is not.