### PR TITLE
Fix - Uncaught TypeError: this.getHolder is not a function

### DIFF
--- a/javascript/display_logic.js
+++ b/javascript/display_logic.js
@@ -281,9 +281,9 @@
 		}
 	});
 
-	$('div.display-logic *').entwine({
+	$('div.field *').entwine({
 		getHolder: function() {
-			return this.closest('.display-logic');
+			return this.parents('.field');
 		}
 	});
 


### PR DESCRIPTION
I was getting the following error when using hasCheckedOption on a CheckboxSetField

`display_logic.js?m=1468213491:198 Uncaught TypeError: this.getHolder is not a function`

Looks like it was because the method `getHolder` was not always available on form inputs, so I've made sure it is :)