### PR TITLE
feat(setMaster): Add 'setMaster' function so that referenced field names can be rewritten. 

### DIFF
--- a/code/DisplayLogicCriteria.php
+++ b/code/DisplayLogicCriteria.php
@@ -168,7 +168,27 @@ class DisplayLogicCriteria extends Object {
 		return $this->logicalOperator == "or" ? "||" : "&&";
 	}
 
+	/**
+	 * Accessor for the master field
+	 * @return string
+	 */
+	public function getMaster() {
+		return $this->master;
+	}
 
+	/**
+	 * @return $this
+	 */
+	public function setMaster($fieldName) {
+		$this->master = $fieldName;
+		$criteria = $this->getCriteria();
+		if ($criteria) {
+			foreach ($criteria as $criterion) {
+				$criterion->setMaster($fieldName);
+			}
+		}
+		return $this;
+	}
 
 	/**
 	 * Creates a nested {@link DisplayLogicCriteria}

--- a/code/DisplayLogicCriterion.php
+++ b/code/DisplayLogicCriterion.php
@@ -70,7 +70,13 @@ class DisplayLogicCriterion extends Object {
 		return $this->master;
 	}
 
-
+	/**
+	 * @return $this
+	 */
+	public function setMaster($fieldName) {
+		$this->master = $fieldName;
+		return $this;
+	}
 
 
 	/**

--- a/code/DisplayLogicFormField.php
+++ b/code/DisplayLogicFormField.php
@@ -89,7 +89,9 @@ class DisplayLogicFormField extends DataExtension {
 		$this->displayLogicCriteria = $c;
 	}
 
-
+	public function getDisplayLogicCriteria() {
+		return $this->displayLogicCriteria;
+	}
 
 
 	/**


### PR DESCRIPTION
feat(setMaster): Add 'setMaster' function so that referenced field names can be rewritten. (ie. I might rewrite a group of fields to have an alternate name with setName() and I want the display logic referenced names to also match the change)

Below is how I'll use this PR in my own MultiRecordField module.

```php
/**
 * Re-write field names to be unique
 * ie. 'Title' to be 'ElementArea__MultiRecordField__ElementGallery__Title'
 *
 * @return \MultiRecordField
 */
public function applyUniqueFieldNames($fields, $record)
{
    $hasDisplayLogic = $this->hasMethod('getDisplayLogicCriteria');
    $isReadonly = $this->isReadonly();
    foreach ($fields->dataFields() as $field)
    {
        // Get all fields underneath/nested in MultiRecordSubRecordField
        $name = $this->getUniqueFieldName($field, $record);
        $field->setName($name);

        // Support Display Logic module by Unclecheese
        if ($hasDisplayLogic) {
            $displayLogicCriteria = $field->getDisplayLogicCriteria();
            if ($displayLogicCriteria !== null) {
                $displayLogicFieldName = $displayLogicCriteria->getMaster();
                $displayLogicFieldName = $this->getUniqueFieldName($displayLogicFieldName, $record);
                $displayLogicCriteria->setMaster($displayLogicFieldName);
            }
        }
    }
    foreach ($fields as $field)
    {
        // This loop is at a top level, so it should all technically just be
        // MultiRecordSubRecordField's only.
        if ($field instanceof MultiRecordSubRecordField) {
            $name = $this->getUniqueFieldName($field, $record);
            $field->setName($name);
        }
        if ($isReadonly) {
            $fields->replaceField($field->getName(), $field = $field->performReadonlyTransformation());
        }
    }
    return $this;
}
```