### PR TITLE
fix(display_logic.js): Update to support 3.2+ field holder ID naming

### DIFF
--- a/javascript/display_logic.js
+++ b/javascript/display_logic.js
@@ -2,7 +2,7 @@
 	$('div.display-logic, div.display-logic-master').entwine({
 
 		escapeSelector: function(selector) {
-			return selector.replace(/(\[)/g, '_').replace(/(\])/g, '')
+			return selector.replace(/(\[)/g, '_').replace(/(\])/g, '');
 		},
 
 		findHolder: function(name) {
@@ -37,13 +37,15 @@
 		nameToHolder: function (name) {
 			name = this.escapeSelector(name);
 
+			// SS 3.2+, Convert::raw2htmlid() logic
+			name = name.replace(/[^a-zA-Z0-9\-_:.]+/g, '_').replace(/_+/g, '_');
+
 			// Hack!
 			// Remove this when OptionsetField_holder.ss uses $HolderID
 			// as its div ID instead of $ID
 			if(this.closest('form').find('ul.optionset li input[name='+name+']:first').length) {
 				return name;
 			}
-
 			return this.getFormID()+'_'+name+'_Holder';
 		},
 
@@ -130,7 +132,7 @@
 
 			masters = this.getMasters();
 
-			for(m in masters) {
+			for(var m in masters) {
 				var holderName = this.nameToHolder(this.escapeSelector(masters[m]));
 				var master = this.closest('form').find(this.escapeSelector('#'+holderName));
 
@@ -188,7 +190,7 @@
 			var found = false;
 			this.find(':checkbox').filter(':checked').each(function() {
 				found = (found || ($(this).val() === val || $(this).getLabel().text() === val));
-			})
+			});
 
 			return found;
 		},
@@ -208,7 +210,7 @@
 		getLabel: function() {
 			return this.closest('form').find('label[for='+this.getHolder().escapeSelector(this.attr('id'))+']');
 		}
-	})
+	});
 
 
 
@@ -263,14 +265,15 @@
 		},
 
 		getListeners: function() {
-			if(l = this._super()) {
+			l = this._super();
+			if(l) {
 				return l;
 			}
 			var self = this;
 			var listeners = [];
 			this.closest("form").find('.display-logic').each(function() {
 				masters = $(this).getMasters();
-				for(m in  masters) {
+				for(var m in masters) {
 					if(self.nameToHolder(masters[m]) == self.attr('id')) {
 						listeners.push($(this)[0]);
 						break;
@@ -288,7 +291,7 @@
 		},
 
 		getFieldName: function () {
-			return ''
+			return '';
 		}
 	});
 


### PR DESCRIPTION
fix(display_logic.js): Update to support 3.2+ field holder ID naming, Fix subtle JavaScript bugs (m in loop not using 'var', ending certain functions in ;)

**Warning:** This might break 3.1 display logic support but will better support 3.2+