### PR TITLE
fix(CSS): .display-logic-hidden is on the field holder div, not just any div with .display-logic-hidden

### DIFF
--- a/css/display_logic.css
+++ b/css/display_logic.css
@@ -1,1 +1,1 @@
-div.display-logic-hidden {display:none;}
+div.field.display-logic-hidden {display:none;}

--- a/css/display_logic.css
+++ b/css/display_logic.css
@@ -1,1 +1,1 @@
-div.field.display-logic-hidden {display:none;}
+div.field.display-logic-hidden, div.displaylogicwrapper.display-logic-hidden {display:none;}


### PR DESCRIPTION
fix(CSS): .display-logic-hidden is on the field holder div, not just any div with .display-logic-hidden.

This resolves a bug where a Select2Field from Select2 module is always hidden:
https://github.com/sheadawson/silverstripe-select2