### PR TITLE
update form templates to support aria roles

### DIFF
--- a/templates/SilverStripe/Forms/CheckboxSetField.ss
+++ b/templates/SilverStripe/Forms/CheckboxSetField.ss
@@ -1,10 +1,10 @@
 <ul id="$ID" class="$extraClass" <% if $DisplayLogic || $DisplayLogicMasters %>name="$Name" data-display-logic-masters="$DisplayLogicMasters" data-display-logic-eval="$DisplayLogic"<% end_if %>>
 	<% if $Options.Count %>
 		<% loop $Options %>
-			<li class="$Class">
+			<li class="$Class" role="$Role">
 				<input id="$ID" class="checkbox" name="$Name" type="checkbox" value="$Value"<% if $isChecked %> checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
 				<label for="$ID">$Title</label>
-			</li> 
+			</li>
 		<% end_loop %>
 	<% else %>
 		<li>No options available</li>

--- a/templates/SilverStripe/Forms/OptionsetField.ss
+++ b/templates/SilverStripe/Forms/OptionsetField.ss
@@ -1,6 +1,6 @@
 <ul $AttributesHTML>
 	<% loop $Options %>
-		<li class="$Class">
+		<li class="$Class" role="$Role">
 			<input id="$ID" class="radio" name="$Name" type="radio" value="$Value"<% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> />
 			<label for="$ID">$Title</label>
 		</li>


### PR DESCRIPTION
makes the form fields use the $Role attribute like the default SilverStripe fields do in:

vendor/silverstripe/framework/templates/SilverStripe/Forms/CheckboxSetField.ss
vendor/silverstripe/framework/templates/SilverStripe/Forms/OptionsetField.ss