### PR TITLE
PHP 8.1: Don't pass null to addslashes function

### DIFF
--- a/src/Criterion.php
+++ b/src/Criterion.php
@@ -90,7 +90,7 @@ class Criterion
             "this.findHolder('%s').evaluate%s('%s')",
             $this->master,
             $this->operator,
-            addslashes($this->value)
+            addslashes($this->value ?? '')
         );
     }
 }


### PR DESCRIPTION
Fixes #140 