### PR TITLE
End() should affect only one layer of Criteria

### DIFF
--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -259,7 +259,7 @@ class Criteria
     {
         if ($this->parent) {
             $this->parent->addCriterion($this);
-            return $this->parent->end();
+            return $this->parent;
         }
         return $this->slave;
     }


### PR DESCRIPTION
As part of the Silverstripe CMS 4 upgrade the [Criteria class](https://github.com/unclecheese/silverstripe-display-logic/commit/eece1d752c9c0c6d93592495b61698addbd3944e#diff-fbbbcc228975daac093ec932a1219707ca5385933508cf66f44004806377f83bL259) was altered to recursively end() all parent groups and return the FormField to which the root Criteria was bound to.

This prevents `group()->rules()->end()->moreRules()->end()` from being a thing. In particular, it prevents a Criteria from having multiple group rules.

The docblock states that end() will return either the FormField or parent Criteria object - currently it only returns FormField which is within that set, so I'm not sure if this constitutes a major change or not.