### PR TITLE
Add Critera api to exit a single group() level

### DIFF
--- a/src/Criteria.php
+++ b/src/Criteria.php
@@ -10,12 +10,13 @@
 
 namespace UncleCheese\DisplayLogic;
 
-use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\Core\Extensible;
-use SilverStripe\Core\Config\Configurable;
-use SilverStripe\Core\Config\Config;
-use SilverStripe\Forms\FormField;
 use BadMethodCallException;
+use OutOfRangeException;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\Forms\FormField;
 
 class Criteria
 {
@@ -252,8 +253,9 @@ class Criteria
     }
 
     /**
-     * Ends the chaining and returns the parent object, either {@link Criteria} or {@link FormField}
-     * @return FormField/Criteria
+     * Ends the chaining and returns the parent {@link FormField}.
+     * Works recursively if in a group {@link Criteria} context
+     * @return FormField
      */
     public function end()
     {
@@ -262,6 +264,21 @@ class Criteria
             return $this->parent->end();
         }
         return $this->slave;
+    }
+
+    /**
+     * Escape a group {@link Criteria}
+     * @return Criteria the parent Criteria
+     * @throws LogicException if there is no parent Criteria
+     */
+    public function endGroup()
+    {
+        if (!$this->parent) {
+            $message = __FUNCTION__ . 'called on Criteria with no parent (not in a group).';
+            $message .= ' Call group() before endGroup(), or perhaps you\'re looking for end() instead.';
+            throw new OutOfRangeException($message);
+        }
+        return $this->parent;
     }
 
     /**

--- a/tests/php/CriteriaTest.php
+++ b/tests/php/CriteriaTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace UncleCheese\DisplayLogic\Tests;
+
+use OutOfRangeException;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\TextField;
+use UncleCheese\DisplayLogic\Criteria;
+
+class CriteriaTest extends SapphireTest
+{
+    public function testEndIsRecursiveAndReturnsTheFormField()
+    {
+        $field = new TextField('test');
+        $displayRulesEnd = $field->displayIf('one')->isEmpty()
+            ->andIf()
+            ->group()
+            ->orIf('two')->isEqualTo('no')
+            ->orIf('two')->isEqualTo('non')
+            ->orIf()
+            ->group() // nested group
+            ->andIf('three')->isEqualTo('yes')
+            ->andIf('four')->isEqualTo('oui')
+            ->end();
+        $this->assertInstanceOf(TextField::class, $displayRulesEnd);
+    }
+
+    public function testEndGroupOnlyReturnsTheParentCriteria()
+    {
+        $field = new TextField('test');
+        $displayRulesEnd = $field->displayIf('one')->isEmpty()
+            ->andIf()
+            ->group()
+            ->orIf('two')->isEqualTo('no')
+            ->orIf('two')->isEqualTo('non')
+            ->endGroup()
+            ->andIf()
+            ->group()
+            ->orIf('three')->isEqualTo('yes')
+            ->orIf('three')->isEqualTo('oui')
+            ->endGroup();
+        $this->assertInstanceOf(Criteria::class, $displayRulesEnd);
+    }
+
+    public function testEndGroupThrowsExceptionWhenThereIsNoParentCriteria()
+    {
+        $this->expectException(OutOfRangeException::class);
+
+        $field = new TextField('test');
+        $displayRulesEnd = $field->displayIf('one')->isEmpty()->endGroup();
+    }
+}


### PR DESCRIPTION
It was decided that 306f813 was too risky a change that could be considered API breaking and thus a major version jump. To reduce this we can add a new method for explicitly escaping a single group level instead of making `Criteria::end()` do two different things depending on context.

This adds the ability for authors to add multiple groups to their display `Criteria`, without interrupting people with nested `group()` rules that rely on `end()` to return the form field the rules apply to*

*(as per 306f813 but then reset to previous functionality of always returning the `FormField` in f124dc8).
Ref. #145 & #146 