### PR TITLE
Update form templates to support aria roles

### DIFF
--- a/templates/SilverStripe/Forms/CheckboxSetField.ss
+++ b/templates/SilverStripe/Forms/CheckboxSetField.ss
@@ -1,7 +1,7 @@
 <ul id="$ID" class="$extraClass" <% if $DisplayLogic || $DisplayLogicDispatchers %>name="$Name" data-display-logic-dispatchers="$DisplayLogicDispatchers" data-display-logic-eval="$DisplayLogic"<% end_if %>>
 	<% if $Options.Count %>
 		<% loop $Options %>
-			<li class="$Class">
+			<li class="$Class" role="$Role">
 				<input id="$ID" class="checkbox" name="$Name" type="checkbox" value="$Value"<% if $isChecked %> checked="checked"<% end_if %><% if $isDisabled %> disabled="disabled"<% end_if %> />
 				<label for="$ID">$Title</label>
 			</li>

--- a/templates/SilverStripe/Forms/OptionsetField.ss
+++ b/templates/SilverStripe/Forms/OptionsetField.ss
@@ -1,6 +1,6 @@
 <ul $AttributesHTML>
 	<% loop $Options %>
-		<li class="$Class">
+		<li class="$Class" role="$Role">
 			<input id="$ID" class="radio" name="$Name" type="radio" value="$Value"<% if $isChecked %> checked<% end_if %><% if $isDisabled %> disabled<% end_if %> />
 			<label for="$ID">$Title</label>
 		</li>


### PR DESCRIPTION
This makes the form fields use the $Role attribute like the default Silverstripe fields do.